### PR TITLE
Fix conditional beta rescaling bug

### DIFF
--- a/R/lasso.R
+++ b/R/lasso.R
@@ -218,7 +218,7 @@ lassoMLE <- function(y, X, lambda = "lambda.min",
   lassoBeta <- lassoBeta * sdy
   conditionalBeta <- conditionalBeta * sdy
   lassoBeta <- lassoBeta / sdX[selected]
-  conidtionalBeta <- conditionalBeta / sdX[selected]
+  conditionalBeta <- conditionalBeta / sdX[selected]
   ysig <- ysig * sdy
   variance <- variance / sdy^2
   condSD <- sqrt(diag(coefVar))


### PR DESCRIPTION
## Summary
- fix a typo in `lassoMLE` causing the conditional coefficients to not be rescaled

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6848a00eb668832d92eff11b6f93fd38