### PR TITLE
Add error-handling regression tests

### DIFF
--- a/tests/testthat/test-lassoMLE.R
+++ b/tests/testthat/test-lassoMLE.R
@@ -12,3 +12,18 @@ test_that("lassoMLE returns expected structure", {
     "non-conformable"
   )
 })
+
+test_that("invalid method argument fails", {
+  set.seed(1)
+  n <- 30
+  p <- 3
+  X <- matrix(rnorm(n * p), n, p)
+  y <- rnorm(n)
+  fit <- glmnet::cv.glmnet(X, y, standardize = FALSE, intercept = FALSE)
+  expect_error(
+    lassoMLE(y, X, lassoFit = fit, method = "bogus",
+             optimSteps = 5, sampSteps = 5,
+             delay = 1, verbose = FALSE),
+    "Method must be either exact or selected!"
+  )
+})

--- a/tests/testthat/test-truncNormMLE-errors.R
+++ b/tests/testthat/test-truncNormMLE-errors.R
@@ -1,0 +1,21 @@
+context("truncNormMLE error handling")
+
+test_that("dimension checks trigger errors", {
+  y <- rnorm(3)
+  sigma <- matrix(1, 2, 2)
+  expect_error(truncNormMLE(y, sigma, threshold = 1, verbose = FALSE),
+               "length of y must equal the dimension of sigma!")
+
+  y2 <- rnorm(4)
+  sigma2 <- matrix(1, 4, 3)
+  expect_error(truncNormMLE(y2, sigma2, threshold = 1, verbose = FALSE),
+               "sigma must be a symmetric matrix!")
+})
+
+test_that("threshold shape validation", {
+  y <- rnorm(2)
+  sigma <- diag(2)
+  thr <- matrix(1, 3, 2)
+  expect_error(truncNormMLE(y, sigma, threshold = thr, verbose = FALSE),
+               "threshold must be either a scalar")
+})


### PR DESCRIPTION
## Summary
- expand lassoMLE tests to cover invalid method argument
- add new tests for truncNormMLE dimension and threshold errors

## Testing
- `Rscript -e 'library(selectiveMLE); testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_6848a547277c832dbe847a92fe8f2214