### PR TITLE
Fix registration of C++ routines

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,4 +3,4 @@
 export(lassoMLE)
 export(truncNormMLE)
 importFrom(Rcpp,sourceCpp)
-useDynLib(selectiveMLE)
+useDynLib(selectiveMLE, .registration = TRUE)


### PR DESCRIPTION
## Summary
- register C++ functions on package load

## Testing
- `R CMD INSTALL .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848b3a3f634832d988f86e76e5d6bca