### PR TITLE
Add Makefile with clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: install clean
+
+install: clean
+	@R CMD INSTALL .
+
+clean:
+	@echo "Cleaning build artifacts"
+	rm -f src/*.o src/*.so src/*.dll
+	@echo "Done."

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ library(devtools)
 install_local("path/to/selectiveMLE")
 ```
 
+Alternatively, use the provided `Makefile`:
+
+```bash
+make install
+```
+
+This calls `R CMD INSTALL` after running `make clean`, which removes any
+compiled artifacts from previous builds. You can invoke `make clean` on its
+own to clear these files without installing the package.
+
 ## Quick example
 
 ```r


### PR DESCRIPTION
## Summary
- add a Makefile to support `make clean` and `make install`
- document the new Makefile usage in the README

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_6848b4e2f128832dbb6447f0919ace02