### PR TITLE
Improve rcpp matrix ops

### DIFF
--- a/src/normalSamplerCpp.cpp
+++ b/src/normalSamplerCpp.cpp
@@ -1,6 +1,9 @@
-#include <Rcpp.h>
+#include <RcppArmadillo.h>
+// [[Rcpp::depends(RcppArmadillo)]]
+// [[Rcpp::plugins(cpp11)]]
 #include "mleHeader.h"
 using namespace Rcpp;
+using namespace arma;
 
 /*
  * normalSamplerCpp.cpp


### PR DESCRIPTION
## Summary
- use Armadillo headers in samplers
- keep matrix helpers but guard zero-case logic
- revert to stable loops for gradient and mean

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_6848b7aafa30832dba1af0d5d2eda314