### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: test
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: devtools
+      - name: Run tests
+        run: |
+          R -q -e 'devtools::install(dependencies = TRUE)'
+          R -q -e 'devtools::test()'


### PR DESCRIPTION
## Summary
- configure GitHub Actions to run `devtools::test()` on pull requests

## Testing
- `apt-get install -y r-base`
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called `testthat`)*

------
https://chatgpt.com/codex/tasks/task_e_6848c078ed18832d81387e6bb8b0536b