### PR TITLE
Fix mvtnorm example

### DIFF
--- a/mvtnorm example script.R
+++ b/mvtnorm example script.R
@@ -1,3 +1,4 @@
+library(selectiveMLE)
 library(reshape2)
 library(ggplot2)
 # Simulation Parameters --------------
@@ -35,9 +36,10 @@ path <- melt(path)
 names(path) <- c("iter", "param", "estimate")
 pathplot <- ggplot(path) + geom_line(aes(x = iter, y = estimate, col = factor(param))) +
   geom_hline(yintercept = 0) + theme_bw() +
-  scale_color_discrete(guide = FALSE) + xlab("Iteration") +
+  scale_color_discrete(guide = "none") + xlab("Iteration") +
   ylab("Estimate")
 pathplot
+if(!dir.exists("figures")) dir.create("figures")
 library(cowplot)
 save_plot(pathplot, file = "figures/mvnPath.pdf",
           base_width = 5, base_height = 3)


### PR DESCRIPTION
## Summary
- load the `selectiveMLE` package in the mvtnorm example
- avoid deprecated `guide=FALSE`
- create figures folder if needed

## Testing
- `R CMD build --no-build-vignettes --no-manual .`
- `R CMD check --no-build-vignettes --no-manual selectiveMLE_0.1.0.tar.gz`
- `Rscript 'mvtnorm example script.R'`

------
https://chatgpt.com/codex/tasks/task_e_684953b25130832d92e1da067b854dcc