### PR TITLE
Improve mvtnorm example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ res$CI
 
 More elaborate demonstrations can be found in the scripts
 `lassoMLE example script.R` and `mvtnorm example script.R` at the top of
-this repository.
+this repository. The latter now logs progress and prints results with
+`knitr::kable` and simple ASCII histograms so that it can be run easily in
+a terminal session.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- make the `mvtnorm` example script terminal-friendly
  - log progress and show an ASCII histogram
  - print estimates in a `knitr::kable` table
- mention the new behaviour in the README

## Testing
- `R -q -e 'library(devtools); load_all(quiet=TRUE); library(testthat); test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_68495a30ff58832d9960027e2ad772de